### PR TITLE
Backport deduping fix and factor out stable_unique

### DIFF
--- a/vowpalwabbit/global_data.cc
+++ b/vowpalwabbit/global_data.cc
@@ -10,6 +10,7 @@ license as described in the file LICENSE.
 #include <sstream>
 #include <math.h>
 #include <assert.h>
+#include <set>
 
 #include "global_data.h"
 #include "gd.h"
@@ -226,6 +227,30 @@ std::vector<std::string> opts_to_args(const std::vector<boost::program_options::
   return args;
 }
 
+// Performs unique operation over collection without requiring the collection to be sorted first.
+// Returns pointer to first element after unique elements to erase from until end of collection.
+// Original ordering of elements is preserved.
+template <typename ForwardIterator>
+ForwardIterator stable_unique(ForwardIterator begin, ForwardIterator end)
+{
+  using value_t = decltype(std::iterator_traits<ForwardIterator>::value_type());
+
+  set<value_t> unique_set;
+
+  auto current_head = begin;
+  for (auto current_check = begin; current_check != end; current_check++)
+  {
+    if (unique_set.find(*current_check) == unique_set.end())
+    {
+      unique_set.insert(*current_check);
+      *current_head = *current_check;
+      current_head++;
+    }
+  }
+
+  return current_head;
+}
+
 // blackbox wrapping of boost program options to ignore duplicate specification of options allowed only ones, but specified multiple times
 // Behavior: only the first occurence is kept
 // Strategy: add one argument after each other until we trigger multiple_occurrences exception. Special care has to be taken of arguments to options.
@@ -251,7 +276,7 @@ po::variables_map add_options_skip_duplicates(vw& all, po::options_description& 
         if (it.second.value().type() == typeid(vector<string>))
         {
           auto& values = it.second.as<vector<string>>();
-          auto end = unique(values.begin(), values.end());
+          auto end = stable_unique(values.begin(), values.end());
           values.erase(end, values.end());
         }
       }


### PR DESCRIPTION
Backport the fix for deduping command line arguments to fix performance degradation overtime from a large command line.